### PR TITLE
fix: correct time estimate typo and add missing dashboard URLs in QUICKSTART.md

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -6,7 +6,7 @@ Get HireHub up and running in 5 minutes!
 
 - Python 3.8+ installed
 - Git installed
-- 10-15 minutes of your time ⏰
+- 5 minutes of your time ⏰
 
 ---
 
@@ -70,6 +70,8 @@ Open your browser and go to:
 
 - **Homepage**: http://127.0.0.1:8000/
 - **Admin Panel**: http://127.0.0.1:8000/admin/
+- **Student Dashboard**: http://127.0.0.1:8000/dashboard/
+- **Recruiter Dashboard**: http://127.0.0.1:8000/recruiter/dashboard/
 
 ---
 


### PR DESCRIPTION
Closes #1

## Changes Made

### QUICKSTART.md
1. **Fixed time estimate typo**: Changed prerequisites from "10-15 minutes of your time" to "5 minutes of your time" to match the header claim "Get HireHub up and running in 5 minutes!"

2. **Added missing dashboard URLs**: Added Student Dashboard and Recruiter Dashboard links to the "Access Application" section to ensure consistency with README.md

## Testing Notes
- No code changes, documentation only
- Verified formatting remains unchanged (markdown structure preserved)
- No unrelated edits made

## Risks
- None - documentation fix only, no functional impact

## Acceptance Criteria Met
- ✅ Corrected typo (time estimate inconsistency)
- ✅ Kept formatting unchanged
- ✅ No unrelated edits
- ✅ Ensured consistency across README sections